### PR TITLE
Release v1.1: Add style property, output error message

### DIFF
--- a/.ABOUT.md
+++ b/.ABOUT.md
@@ -64,8 +64,9 @@ In this example, `PrinterLink` is added to the Apollo Client link chain. The `op
 
 | name | type | explanation |
 | --- | --- | --- |
-| ```print``` | boolean | if ```true```, information will be output to the console |
-| ```collapsed``` | boolean | if ```true```, ```console.groupCollapsed``` will be used, otherwise ```console.group``` |
+| `print` | boolean | if `true`, information will be output to the console |
+| `collapsed` | boolean | if `true`, `console.groupCollapsed` will be used, otherwise `console.group` |
+| `style` | string | This option accepts two values: `off` and `css`. Selecting `off` disables the stylized output |
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "apollo-link-printer",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "apollo-link-printer",
-      "version": "1.0.0",
+      "version": "1.0.3",
       "license": "MIT",
       "devDependencies": {
         "@apollo/client": "^3.11.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-link-printer",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Pretty logger of Apollo GraphQL network operations packaged in a Apollo link",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-link-printer",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Pretty logger of Apollo GraphQL network operations packaged in a Apollo link",
   "type": "module",
   "scripts": {

--- a/src/__tests__/printerLink.spec.ts
+++ b/src/__tests__/printerLink.spec.ts
@@ -51,12 +51,12 @@ describe('Operation Row', () => {
       titleBadgeStyle,
       titleTextStyle
     ];
-    const row = operationRow(operation);
+    const row = operationRow(operation, 'css', true, []);
     expect(row).toEqual(expect.arrayContaining(expected));
   });
 
   it('Defines the name of operation', () => {
-    const row = operationRow(operation);
+    const row = operationRow(operation, 'css', true, []);
     expect(row).toContain('%c QUERY %c ');
   });
 });
@@ -88,7 +88,7 @@ describe('Fragemnt Row', () => {
         // @ts-expect-error desc
         definitions: [DocumentNodeQuery]
       }
-    });
+    }, 'css');
     expect(data).toHaveLength(0);
   })
 });
@@ -101,7 +101,7 @@ describe('Variables Row', () => {
       ''
     ]
     // @ts-expect-error desc
-    const row = variablesRow(operation);
+    const row = variablesRow(operation, 'css');
     expect(row).toEqual(expect.arrayContaining(expected));
   });
 });
@@ -113,7 +113,7 @@ describe('Message Row', () => {
       rowBadgeStyle, ''
     ]
     // @ts-expect-error desc
-    const row = messageRow(operation);
+    const row = messageRow(operation, 'css');
     expect(row).toEqual(expect.arrayContaining(expected));
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { PrinterLink } from './printerLink';
+export { PrinterLink } from './printerLink.js';

--- a/src/printerLink.ts
+++ b/src/printerLink.ts
@@ -1,6 +1,6 @@
 import { ApolloLink, NextLink, Operation } from '@apollo/client';
-import { fragmentRow, messageRow, operationRow, variablesRow } from './rows';
-import { TLinkOptions } from './printerLink.types';
+import { fragmentRow, messageRow, operationRow, variablesRow } from './rows/index.js';
+import { TLinkOptions } from './printerLink.types.js';
 
 const prepareSubrows = (operation: Operation) => {
     const result = {

--- a/src/printerLink.ts
+++ b/src/printerLink.ts
@@ -2,15 +2,18 @@ import { ApolloLink, NextLink, Operation } from '@apollo/client';
 import { fragmentRow, messageRow, operationRow, variablesRow } from './rows/index.js';
 import { TLinkOptions } from './printerLink.types.js';
 
-const prepareSubrows = (operation: Operation) => {
+const prepareSubrows = (operation: Operation, options: TLinkOptions) => {
     const result = {
         isSingleRow: true,
         subrows: [],
     }
+    const { style = 'css' } = options;
+
+
     const rows = [fragmentRow, variablesRow, messageRow];
 
     rows.forEach((handler) => {
-        const row = handler(operation);
+        const row = handler(operation, style);
         
         if (row.length) {
             result.isSingleRow = false;
@@ -22,8 +25,10 @@ const prepareSubrows = (operation: Operation) => {
 };
 
 const printer = (operation: Operation, options: TLinkOptions) => {
-    const mainrow = operationRow(operation);
-    const { isSingleRow, subrows } = prepareSubrows(operation);
+    const { style = 'css' } = options;
+    const mainrow = operationRow(operation, style);
+    const { isSingleRow, subrows } = prepareSubrows(operation, options);
+    
     try {
         if (isSingleRow) {
             console.log(...mainrow);

--- a/src/printerLink.ts
+++ b/src/printerLink.ts
@@ -1,5 +1,5 @@
 import { ApolloLink, NextLink, Operation } from '@apollo/client';
-import { fragmentRow, messageRow, operationRow, variablesRow } from './rows/index.js';
+import { errorsRow, fragmentRow, messageRow, operationRow, variablesRow, } from './rows/index.js';
 import { TLinkOptions } from './printerLink.types.js';
 
 const prepareSubrows = (operation: Operation, options: TLinkOptions) => {
@@ -9,12 +9,11 @@ const prepareSubrows = (operation: Operation, options: TLinkOptions) => {
     }
     const { style = 'css' } = options;
 
-
     const rows = [fragmentRow, variablesRow, messageRow];
 
     rows.forEach((handler) => {
         const row = handler(operation, style);
-        
+
         if (row.length) {
             result.isSingleRow = false;
             result.subrows.push(row);
@@ -24,11 +23,17 @@ const prepareSubrows = (operation: Operation, options: TLinkOptions) => {
     return result;
 };
 
-const printer = (operation: Operation, options: TLinkOptions) => {
+const printer = (
+    operation: Operation,
+    options: TLinkOptions,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    errors: any = [],
+    isOK: boolean
+) => {
     const { style = 'css' } = options;
-    const mainrow = operationRow(operation, style);
+    const mainrow = operationRow(operation, style, isOK, errors);
     const { isSingleRow, subrows } = prepareSubrows(operation, options);
-    
+
     try {
         if (isSingleRow) {
             console.log(...mainrow);
@@ -36,12 +41,16 @@ const printer = (operation: Operation, options: TLinkOptions) => {
             const { collapsed = false } = options;
             const group = collapsed ? 'groupCollapsed' : 'group'
 
-            console[group](...mainrow) 
+            console[group](...mainrow)
+            errors.forEach((error) => {
+                const subrow = errorsRow(error, style);
+                console.log(...subrow);
+            })
             subrows.forEach((subrow) => {
                 console.log(...subrow);
             });
             console.groupEnd();
-        }     
+        }
     } catch (err) {
         console.error(err);
     }
@@ -49,16 +58,19 @@ const printer = (operation: Operation, options: TLinkOptions) => {
 
 function operationPrinter(options: TLinkOptions) {
     return new ApolloLink(((operation, forward) => {
-        try {
-            const { print = true, ...otherOptions } = options;
-
-            if (print) {
-                printer(operation, otherOptions);
+        return forward(operation).map((response) => {
+            try {
+                const { print = true, ...otherOptions } = options;
+                if (print) {
+                    const { errors = [] } = response;
+                    const isOK = 'data' in response;
+                    printer(operation, otherOptions, errors, isOK);
+                }
+            } catch (errMsg) {
+                console.error(errMsg);
             }
-        } catch (errMsg) {
-            console.error(errMsg);
-        }
-        return forward(operation);
+            return response;
+        });
     }));
 }
 

--- a/src/printerLink.types.ts
+++ b/src/printerLink.types.ts
@@ -1,4 +1,7 @@
+export type TStyle = 'css' | 'off'
+
 export type TLinkOptions = {
     print?: boolean,
     collapsed?: boolean,
+    style?: TStyle,
 }

--- a/src/rows/index.ts
+++ b/src/rows/index.ts
@@ -72,7 +72,7 @@ export const operationRow = ({ query: { definitions = [] }, operationName }: Ope
     const operationType = definition.operation || 'unknown'
 
     return [
-        `%c ${operationType.toUpperCase()} %c ${operationName} _DEV_`,
+        `%c ${operationType.toUpperCase()} %c ${operationName}`,
         titleBadgeStyle, titleTextStyle,
     ];
 };

--- a/src/rows/index.ts
+++ b/src/rows/index.ts
@@ -67,11 +67,12 @@ export const fragmentRow = ({ query: { definitions } }: Operation) => {
  * @param {Operation} operation
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const operationRow = ({ query: { definitions }, operationName }: Operation | any) => {
-    const [{ operation: operationType }] = definitions;
+export const operationRow = ({ query: { definitions = [] }, operationName }: Operation | any) => {
+    const definition = definitions.find(({ kind }) => kind === 'OperationDefinition');
+    const operationType = definition.operation || 'unknown'
 
     return [
-        `%c ${operationType.toUpperCase()} %c ${operationName}`,
+        `%c ${operationType.toUpperCase()} %c ${operationName} _DEV_`,
         titleBadgeStyle, titleTextStyle,
     ];
 };

--- a/src/rows/index.ts
+++ b/src/rows/index.ts
@@ -4,9 +4,24 @@ import { TStyle } from '../printerLink.types';
 /* CSS */
 const bold = 'font-weight: bold';
 
-export const titleBadgeStyle = `background-color: #abe9b2; color: black; border-radius: 2px; ${bold}`;
+export const titleBadgeStyle = `background-color: #abe9b2; color: #000000; ${bold}`;
+export const titleBadgeStyleNoResponse = `background-color: #FF6275; color: #000000; ${bold}`;
 export const titleTextStyle = `${bold}`;
 export const rowBadgeStyle = `color: #cfc167; ${bold}`;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const errorsRow = (error: any, style: TStyle) => {
+       const { message } = error;
+    
+     if (style === 'off') {
+        return [`Error message : ${message}`,]
+    };
+
+    return [
+        `%cError message :%c ${message}`,
+        rowBadgeStyle, '',
+    ];
+}
 
 /**
  * @param {Operation} operation
@@ -82,8 +97,11 @@ export const fragmentRow = ({ query: { definitions } }: Operation, style: TStyle
  * @param {Operation} operation
  */
 export const operationRow = (
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    { query: { definitions = [] }, operationName }: Operation | any, style: TStyle
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    { query: { definitions = [] }, operationName }: Operation | any, 
+    style: TStyle, 
+    isOK: boolean,
+    errors: any = [],
 ) => {
     const definition = definitions.find(({ kind }) => kind === 'OperationDefinition');
     const operationType = definition.operation || 'unknown'
@@ -92,8 +110,20 @@ export const operationRow = (
         return [`${operationType.toUpperCase()} : ${operationName}`]
     };
 
-    return [
+    const titleStyle = isOK ? titleBadgeStyle : titleBadgeStyleNoResponse;
+    const isError = !!errors.length;
+
+    const ok = [
         `%c ${operationType.toUpperCase()} %c ${operationName}`,
-        titleBadgeStyle, titleTextStyle,
+        titleStyle, titleTextStyle,
     ];
+    
+    const error = [
+        `%c ${operationType.toUpperCase()} %c ERROR %c ${operationName}`,
+        titleStyle, titleBadgeStyleNoResponse, titleTextStyle,
+    ];
+
+    const message = isError ?  error : ok;
+
+    return message;
 };

--- a/src/rows/index.ts
+++ b/src/rows/index.ts
@@ -1,4 +1,5 @@
 import { Operation } from '@apollo/client';
+import { TStyle } from '../printerLink.types';
 
 /* CSS */
 const bold = 'font-weight: bold';
@@ -11,11 +12,16 @@ export const rowBadgeStyle = `color: #cfc167; ${bold}`;
  * @param {Operation} operation
  * @returns
  */
-export const messageRow = (operation: Operation) => {
+export const messageRow = (operation: Operation, style: TStyle) => {
     const { message } = operation.getContext();
     if (!message && typeof message !== 'string') {
         return [];
     }
+
+    if (style === 'off') {
+        return [`Message : ${message}`,]
+    };
+
     return [
         `%cMessage :%c ${message}`,
         rowBadgeStyle, '',
@@ -26,12 +32,16 @@ export const messageRow = (operation: Operation) => {
  * @param {*} Operation
  * @returns
  */
-export const variablesRow = ({ variables }: Operation) => {
+export const variablesRow = ({ variables }: Operation, style: TStyle) => {
     if (!Object.keys(variables).length) {
         return [];
     }
 
     const content = JSON.stringify(variables, null, 1);
+
+    if (style === 'off') {
+        return [`Variables : ${content}`,]
+    };
 
     return [
         `%cVariables :%c ${content}`,
@@ -43,7 +53,7 @@ export const variablesRow = ({ variables }: Operation) => {
  * @description takes information about the included fragments in the request and formats them
  * @param {Operation} operation
  */
-export const fragmentRow = ({ query: { definitions } }: Operation) => {
+export const fragmentRow = ({ query: { definitions } }: Operation, style: TStyle) => {
     const II = definitions.reduce((acc, item) => {
         const isFragementType = item.kind === 'FragmentDefinition';
         if (isFragementType) { return [...acc, item.name.value]; }
@@ -56,6 +66,11 @@ export const fragmentRow = ({ query: { definitions } }: Operation) => {
 
     const text = II.length > 1 ? 'Includes fragments :' : 'Includes fragment :';
     const fragmentsNames = II.join(', ');
+
+    if (style === 'off') {
+        return [`${text} ${fragmentsNames}`,]
+    };
+
     return [
         `%c${text} %c${fragmentsNames}`,
         rowBadgeStyle, '',
@@ -66,15 +81,19 @@ export const fragmentRow = ({ query: { definitions } }: Operation) => {
  * @description takes the value of operation type and operationName and formats them
  * @param {Operation} operation
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const operationRow = ({ query: { definitions = [] }, operationName }: Operation | any) => {
+export const operationRow = (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    { query: { definitions = [] }, operationName }: Operation | any, style: TStyle
+) => {
     const definition = definitions.find(({ kind }) => kind === 'OperationDefinition');
     const operationType = definition.operation || 'unknown'
+
+    if (style === 'off') {
+        return [`${operationType.toUpperCase()} : ${operationName}`]
+    };
 
     return [
         `%c ${operationType.toUpperCase()} %c ${operationName}`,
         titleBadgeStyle, titleTextStyle,
     ];
 };
-
-


### PR DESCRIPTION
### New Features & Improvements
1. Added style field
    * This field accepts one of two values:
        * off: Disables all styling (plain console output).
        * css: Applies CSS-based styling (default).
    * Coming soon: A third option, ansi, will allow switching from CSS to ANSI escape sequences for styling.
2. Error & Warning Badges
    * A red badge now appears when a request fails (processed with an error).
    * If a request completes without a response (e.g., missing the required data field), the operation-type badge also turns red to indicate the issue.
